### PR TITLE
Fix: Display dates correctly depending on locale

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -61,20 +61,7 @@ export default function App() {
     //If locale isn't in the translations object, it'll default to English
     const deviceLocal = translations[userLocale] ? userLocale : "en";
     i18n.locale = deviceLocal;
-    moment.updateLocale(i18n.locale, {
-      longDateFormat: {
-        LT: clockStyle,
-        LTS: "h:mm:ss A",
-        L: "MM/DD/YYYY",
-        l: "M/D/YYYY",
-        LL: "MMMM Do YYYY",
-        ll: "MMM D YYYY",
-        LLL: "MMMM Do YYYY LT",
-        lll: "MMM D YYYY LT",
-        LLLL: "dddd, MMMM Do YYYY LT",
-        llll: "ddd, MMM D YYYY LT",
-      },
-    });
+    moment.locale(deviceLocal);
   };
 
   useEffect(() => {

--- a/src/components/CardHeader/CardHeader.tsx
+++ b/src/components/CardHeader/CardHeader.tsx
@@ -15,7 +15,7 @@ const CardHeader = () => {
         {i18n.t("Today")}
       </Text>
       <Text style={[typography.headerText, cardHeaderStyles.dateText]}>
-        {context?.date.format("MMMM Do YYYY")}
+        {context.date.format("LL")}
       </Text>
     </View>
   );


### PR DESCRIPTION
This PR fixes the locale date issue
[Issue Link](https://github.com/EladKarni/rn-dualtemp-weather/issues/18)